### PR TITLE
feat(core): Adds per logging-level logs masking.

### DIFF
--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -123,11 +123,11 @@ class ApiClient:
                 timeout=self.request_timeout,
             )
 
-        should_logs_masking: bool = LOG.getEffectiveLevel() >= logging.DEBUG or LOG.getEffectiveLevel() == logging
+        should_logs_masking: bool = LOG.getEffectiveLevel() > logging.DEBUG or LOG.getEffectiveLevel() == logging
 
         logged_body: Union[dict, str, None] = None
         if body:
-            logged_body = json.loads(body.json()) if should_logs_masking else str(body.dict())
+            logged_body = str(body.dict()) if should_logs_masking else json.loads(body.json())
 
         request_log_message = log_util.request_log(
             headers=request_headers,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -16,7 +16,7 @@ import json
 import logging
 import uuid
 from http import HTTPStatus
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import pydantic
 import pydantic.schema
@@ -123,9 +123,13 @@ class ApiClient:
                 timeout=self.request_timeout,
             )
 
+        logged_body: Union[dict, str, None] = None
+        if body:
+            logged_body = str(body.dict()) if LOG.getEffectiveLevel() <= logging.DEBUG else body.json()
+
         request_log_message = log_util.request_log(
             headers=request_headers,
-            body=str(body.dict()) if LOG.getEffectiveLevel() <= logging.DEBUG else body.json(),
+            body=logged_body,
             endpoint=url,
             method=method,
             response=response,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -123,11 +123,7 @@ class ApiClient:
                 timeout=self.request_timeout,
             )
 
-        should_mask_logs: bool = LOG.getEffectiveLevel() > logging.DEBUG or LOG.getEffectiveLevel() == logging.NOTSET
-
-        logged_body: dict = dict()
-        if body:
-            logged_body = body.dict() if should_mask_logs else json.loads(body.json())
+        logged_body: dict[str, Any] = dict() if not body else body.dict()
 
         request_log_message = log_util.request_log(
             headers=request_headers,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -103,7 +103,6 @@ class ApiClient:
         """
         self.__auth_client.refresh_token()
         request_headers = ApiClient.__prepare_request_headers(headers)
-        request_body = dict()
 
         if not body:
             response = requests.request(
@@ -126,7 +125,7 @@ class ApiClient:
 
         request_log_message = log_util.request_log(
             headers=request_headers,
-            body=str(request_body),
+            body=str(body.dict()) if LOG.getEffectiveLevel() <= logging.DEBUG else body.json(),
             endpoint=url,
             method=method,
             response=response,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -123,9 +123,11 @@ class ApiClient:
                 timeout=self.request_timeout,
             )
 
+        should_logs_masking: bool = LOG.getEffectiveLevel() >= logging.DEBUG or LOG.getEffectiveLevel() == logging
+
         logged_body: Union[dict, str, None] = None
         if body:
-            logged_body = str(body.dict()) if LOG.getEffectiveLevel() <= logging.DEBUG else body.json()
+            logged_body = json.loads(body.json()) if should_logs_masking else str(body.dict())
 
         request_log_message = log_util.request_log(
             headers=request_headers,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -123,11 +123,11 @@ class ApiClient:
                 timeout=self.request_timeout,
             )
 
-        should_logs_masking: bool = LOG.getEffectiveLevel() > logging.DEBUG or LOG.getEffectiveLevel() == logging
+        should_mask_logs: bool = LOG.getEffectiveLevel() > logging.DEBUG or LOG.getEffectiveLevel() == logging.NOTSET
 
         logged_body: Union[dict, str, None] = None
         if body:
-            logged_body = str(body.dict()) if should_logs_masking else json.loads(body.json())
+            logged_body = str(body.dict()) if should_mask_logs else json.loads(body.json())
 
         request_log_message = log_util.request_log(
             headers=request_headers,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -125,13 +125,13 @@ class ApiClient:
 
         should_mask_logs: bool = LOG.getEffectiveLevel() > logging.DEBUG or LOG.getEffectiveLevel() == logging.NOTSET
 
-        logged_body: Union[dict, str, None] = None
+        logged_body: dict = dict()
         if body:
-            logged_body = str(body.dict()) if should_mask_logs else json.loads(body.json())
+            logged_body = body.dict() if should_mask_logs else json.loads(body.json())
 
         request_log_message = log_util.request_log(
             headers=request_headers,
-            body=logged_body,
+            body=str(logged_body),
             endpoint=url,
             method=method,
             response=response,

--- a/expediagroup/sdk/core/client/api.py
+++ b/expediagroup/sdk/core/client/api.py
@@ -16,7 +16,7 @@ import json
 import logging
 import uuid
 from http import HTTPStatus
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import pydantic
 import pydantic.schema

--- a/expediagroup/sdk/core/util/log.py
+++ b/expediagroup/sdk/core/util/log.py
@@ -45,7 +45,7 @@ def request_log(headers: dict, body: str, endpoint: str, method: str, response: 
 
     result = f"\nRequest: {endpoint}\n" f"Method: {method.upper()}\n" + log.HTTP_HEADERS_LOG_MESSAGE_TEMPLATE.format(
         headers_log
-    ) + log.HTTP_BODY_LOG_MESSAGE_TEMPLATE.format("\t\t" + body + "\n") + response_log(response)
+    ) + log.HTTP_BODY_LOG_MESSAGE_TEMPLATE.format("\t\t" + str(body) + "\n") + response_log(response)
 
     return result
 

--- a/expediagroup/sdk/core/util/log.py
+++ b/expediagroup/sdk/core/util/log.py
@@ -45,7 +45,7 @@ def request_log(headers: dict, body: str, endpoint: str, method: str, response: 
 
     result = f"\nRequest: {endpoint}\n" f"Method: {method.upper()}\n" + log.HTTP_HEADERS_LOG_MESSAGE_TEMPLATE.format(
         headers_log
-    ) + log.HTTP_BODY_LOG_MESSAGE_TEMPLATE.format("\t\t" + str(body) + "\n") + response_log(response)
+    ) + log.HTTP_BODY_LOG_MESSAGE_TEMPLATE.format("\t\t" + body + "\n") + response_log(response)
 
     return result
 

--- a/expediagroup/sdk/generator/client/templates/__model__.jinja2
+++ b/expediagroup/sdk/generator/client/templates/__model__.jinja2
@@ -20,6 +20,8 @@ from expediagroup.sdk.core.model.exception.service import ExpediaGroupApiExcepti
 SecretStr.__str__ = lambda self: '<-- omitted -->' if self.get_secret_value() else ''
 
 class PydanticModelConfig:
+    r"""List of configurations for all SDK models."""
+
     JSON_ENCODERS = {
         SecretStr: lambda v: v.get_secret_value() if v else None,
         SecretBytes: lambda v: v.get_secret_value() if v else None,

--- a/expediagroup/sdk/generator/client/templates/__model__.jinja2
+++ b/expediagroup/sdk/generator/client/templates/__model__.jinja2
@@ -17,6 +17,8 @@ from pydantic import Extra, validator, SecretStr, SecretBytes
 from pydantic.dataclasses import dataclass
 from expediagroup.sdk.core.model.exception.service import ExpediaGroupApiException
 
+SecretStr.__str__ = lambda self: '<-- omitted -->' if self.get_secret_value() else ''
+
 class PydanticModelConfig:
     JSON_ENCODERS = {
         SecretStr: lambda v: v.get_secret_value() if v else None,

--- a/expediagroup/sdk/generator/client/templates/__model__.jinja2
+++ b/expediagroup/sdk/generator/client/templates/__model__.jinja2
@@ -20,7 +20,7 @@ from expediagroup.sdk.core.model.exception.service import ExpediaGroupApiExcepti
 SecretStr.__str__ = lambda self: '<-- omitted -->' if self.get_secret_value() else ''
 
 class PydanticModelConfig:
-    r"""List of configurations for all SDK models."""
+    r"""List of configurations for all SDK pydantic models."""
 
     JSON_ENCODERS = {
         SecretStr: lambda v: v.get_secret_value() if v else None,

--- a/expediagroup/sdk/generator/client/templates/__model__.jinja2
+++ b/expediagroup/sdk/generator/client/templates/__model__.jinja2
@@ -13,9 +13,19 @@
 {# limitations under the License.#}
 {{ model_imports }}
 from typing import Union, Any, Literal
-from pydantic import Extra
+from pydantic import Extra, validator, SecretStr, SecretBytes
 from pydantic.dataclasses import dataclass
 from expediagroup.sdk.core.model.exception.service import ExpediaGroupApiException
+
+class PydanticModelConfig:
+    JSON_ENCODERS = {
+        SecretStr: lambda v: v.get_secret_value() if v else None,
+        SecretBytes: lambda v: v.get_secret_value() if v else None,
+    }
+
+    EXTRA: bool = Extra.forbid
+
+    SMART_UNION: bool = True
 
 
 {% for model in models %}
@@ -23,18 +33,16 @@ from expediagroup.sdk.core.model.exception.service import ExpediaGroupApiExcepti
 {{ decorator }}
 {% endfor -%}
 
-class {{ model.class_name }}{% if is_aliased[model.class_name] %}Generic{% endif %}({{ model.base_class }}{% if is_aliased[model.base_class] %}Generic{% endif %},{% if model.base_class != 'Enum' %} smart_union=True, extra=Extra.forbid,{% endif %}): {% if comment is defined %}  # {{ model.comment }}{% endif %}
+class {{ model.class_name }}{% if is_aliased[model.class_name] %}Generic{% endif %}({{ model.base_class }}{% if is_aliased[model.base_class] %}Generic{% endif %},{% if model.base_class != 'Enum' %} smart_union=PydanticModelConfig.SMART_UNION, extra=PydanticModelConfig.EXTRA, json_encoders=PydanticModelConfig.JSON_ENCODERS{% endif %}): {% if comment is defined %}  # {{ model.comment }}{% endif %}
     r"""pydantic model {{ model.class_name }}{%- if model.description %}: {{ model.description }}{%- endif %}
 {# comment for new line #}
 """
 {% if model.class_name in omitted_log_fields.keys() %}
-    def dict(self, **kwargs):
-        omitted_fields = {{ omitted_log_fields[model.class_name] }}
-
-        dictionary = super().dict(**kwargs)
-        dictionary.update([(attribute, "<-- omitted -->") for attribute in omitted_fields])
-
-        return dictionary
+    {% for field in omitted_log_fields[model.class_name] %}
+    @validator("{{ field }}")
+    def __{{ field }}_validator(cls, {{ field }}):
+        return SecretStr(str({{ field }}))
+    {% endfor %}
 {% endif %}
 
 {%- if not model.fields %}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [X] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->
## Results
Example of masked results on the default logging level (`INFO`):
```python
{
    'card_cvv_response': SecretStr('<-- omitted -->'),
    'card_number': SecretStr('<-- omitted -->'),
}
```

## Background
Overriding the `.dict()` method has it flaws, one example is that when a model object is inside a dictionary, calling the `.json()` method would call the `.dict()` method on attributes depth `> 1`, resulting in omitting few fields in the JSON request body. Another flaw is that this solution cannot be replicated at migration to [Pydantic 2](https://docs.pydantic.dev/latest/blog/pydantic-v2-final/).

After deeper research, I found that using [Secret Types](https://docs.pydantic.dev/1.10/usage/types/#secret-types) is the recommended way to handle such sensitive data. It is also migrated to and improved in [Pydantic 2](https://docs.pydantic.dev/latest/blog/pydantic-v2-final/).

