### PR TITLE
fix(docs-generator): Set attribute datatype to `typing.Any` if missing.

### DIFF
--- a/expediagroup/sdk/docsgen/model.py
+++ b/expediagroup/sdk/docsgen/model.py
@@ -156,6 +156,9 @@ class Attribute(DocumentedObject):
         if not other:
             raise ValueError(str(other))
 
+        if not other.datatype:
+            other.datatype = str(Any)
+
         return Attribute(
             name=other.name,
             datatype=other.datatype,

--- a/expediagroup/sdk/generator/client/templates/__model__.jinja2
+++ b/expediagroup/sdk/generator/client/templates/__model__.jinja2
@@ -12,7 +12,7 @@
 {# See the License for the specific language governing permissions and#}
 {# limitations under the License.#}
 {{ model_imports }}
-from typing import Union, Any, Literal
+from typing import Union, Any, Literal, Callable
 from pydantic import Extra, validator, SecretStr, SecretBytes
 from pydantic.dataclasses import dataclass
 from expediagroup.sdk.core.model.exception.service import ExpediaGroupApiException
@@ -22,7 +22,7 @@ SecretStr.__str__ = lambda self: '<-- omitted -->' if self.get_secret_value() el
 class PydanticModelConfig:
     r"""List of configurations for all SDK pydantic models."""
 
-    JSON_ENCODERS = {
+    JSON_ENCODERS: dict[type, Callable] = {
         SecretStr: lambda v: v.get_secret_value() if v else None,
         SecretBytes: lambda v: v.get_secret_value() if v else None,
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- 

### :link: Related Issues
- 
