### PR TITLE
build(quality): Ignore W291 lint rule.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,7 +10,7 @@ count = True
 pep585-activation = always
 
 per-file-ignores =
-    release/*: BLK100, E501, F722, W391, W505
+    release/*: BLK100, E501, F722, W391, W505, W291
 
 ignore =
     B008


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Ignores W291 (Trailing whitespace in docstrings).

### :link: Related Issues
- 
