### PR TITLE
fix(github): Fix format code step in publish sources action.

### DIFF
--- a/.github/workflows/generator-main.yaml
+++ b/.github/workflows/generator-main.yaml
@@ -56,7 +56,6 @@ jobs:
       name: ${{ github.event.inputs.name }}
 
   publish_sources:
-    if: ${{ github.event.inputs.production_release == 'true' }}
     needs: [ generate_sdk ]
     uses: ./.github/workflows/generator-publish-sources.yaml
     with:

--- a/.github/workflows/generator-main.yaml
+++ b/.github/workflows/generator-main.yaml
@@ -56,6 +56,7 @@ jobs:
       name: ${{ github.event.inputs.name }}
 
   publish_sources:
+    if: ${{ github.event.inputs.production_release == 'true' }}
     needs: [ generate_sdk ]
     uses: ./.github/workflows/generator-publish-sources.yaml
     with:

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,9 +44,9 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          docformatter --recursive --black --in-place --close-quotes-on-newline release
           isort release
           black release
+          docformatter --recursive --black --in-place --close-quotes-on-newline release
       - name: Create PR
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -43,7 +43,6 @@ jobs:
           find ./ -name \*.yaml -exec cp {} ../../../../release/"${{github.event.inputs.name}}"/src/ \;
       - name: Format Code
         run: |
-          sudo pip3 install --upgrade pip
           sudo pip3 install -r requirements-dev.txt
 
           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline release

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          sudo docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
+          docformatter --recursive --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          sudo docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
+           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
+          sudo docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -43,7 +43,10 @@ jobs:
           find ./ -name \*.yaml -exec cp {} ../../../../release/"${{github.event.inputs.name}}"/src/ \;
       - name: Format Code
         run: |
-          sudo pip3 install -r requirements-dev.txt
+          python3 -m venv venv
+          source venv/bin/activate
+
+          pip3 install -r requirements-dev.txt
 
           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline release
           isort release

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -43,10 +43,7 @@ jobs:
           find ./ -name \*.yaml -exec cp {} ../../../../release/"${{github.event.inputs.name}}"/src/ \;
       - name: Format Code
         run: |
-          python3 -m venv venv
-          source venv/bin/activate
-
-          pip3 install -r requirements-dev.txt
+          sudo pip3 install -r requirements-dev.txt
 
           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline release
           isort release

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
+          docformatter --recursive --black --in-place --close-quotes-on-newline release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -46,7 +46,6 @@ jobs:
           pip3 install -r requirements-dev.txt
           isort release
           black release
-          docformatter --recursive --black --in-place --close-quotes-on-newline release
       - name: Create PR
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          docformatter --recursive --in-place --close-quotes-on-newline --config pyproject.toml release
+          docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -43,12 +43,8 @@ jobs:
           find ./ -name \*.yaml -exec cp {} ../../../../release/"${{github.event.inputs.name}}"/src/ \;
       - name: Format Code
         run: |
-          python3 -m venv venv
-          source venv/bin/activate
-
           pip3 install -r requirements-dev.txt
-
-          sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline release
+           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -43,8 +43,12 @@ jobs:
           find ./ -name \*.yaml -exec cp {} ../../../../release/"${{github.event.inputs.name}}"/src/ \;
       - name: Format Code
         run: |
+          python3 -m venv venv
+          source venv/bin/activate
+
           pip3 install -r requirements-dev.txt
-           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
+
+          sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,9 +44,9 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
+          docformatter --recursive --black --in-place --close-quotes-on-newline release
           isort release
           black release
-          docformatter --recursive --black --in-place --close-quotes-on-newline release
       - name: Create PR
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -43,6 +43,7 @@ jobs:
           find ./ -name \*.yaml -exec cp {} ../../../../release/"${{github.event.inputs.name}}"/src/ \;
       - name: Format Code
         run: |
+          sudo pip3 install --upgrade pip
           sudo pip3 install -r requirements-dev.txt
 
           sudo python3 -m docformatter --recursive --black --in-place --close-quotes-on-newline release

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          docformatter --recursive --black --in-place --close-quotes-on-newline release
+          docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
+          docformatter --recursive --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR

--- a/.github/workflows/generator-publish-sources.yaml
+++ b/.github/workflows/generator-publish-sources.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Format Code
         run: |
           pip3 install -r requirements-dev.txt
-          docformatter --recursive --in-place --close-quotes-on-newline --config pyproject.toml release
+          sudo docformatter --recursive --black --in-place --close-quotes-on-newline --config pyproject.toml release
           isort release
           black release
       - name: Create PR


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [X] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
In the workflow for publishing generator sources, the order of execution for linting tools is changed.

The docformatter is now run before isort and black. The change aims to ensure consistent documentation formatting across the codebase before other linting tools are executed. This is necessary for maintaining the code cleanliness and readability.


### :link: Related Issues
- 
