### PR TITLE
chore(deps-dev): roll back flake8 version to v6

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ autoflake~=2.2.1
 build~=1.0.3
 setuptools~=69.0.3
 fastapi-code-generator==0.4.4
-flake8~=7.0.0
+flake8~=6.0.0
 flake8-black~=0.3.6
 flake8-bugbear~=24.1.17
 flake8-isort~=6.1.1


### PR DESCRIPTION
* [X] Code is up-to-date with the `main` branch.
* [X] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

## Description
The version of `datamodel-code-generator` used by the `fastapi-code-generator` uses version `6.X.X` of `flake8`. Obviously `flake8` version `7.X.X` comes with a breaking change that breaks our SDK generator. As a conclusion, we are forced to stick with version `6.X.X` of `flake8` for the time being.

