### PR TITLE
fix: pr title lint validation

### DIFF
--- a/.github/workflows/contribution-lint.yaml
+++ b/.github/workflows/contribution-lint.yaml
@@ -38,4 +38,4 @@ jobs:
       - name: Run Pull Request Title Validation
         run: echo "${{ github.event.pull_request.title }}" | npx commitlint --config commitlint.config.js --verbose
       - name: Run Latest Commit Message Validation
-        run: git log -1 --pretty=format:"%s" | npx commitlint --config commitlint.config.js --verbose
+        run: git log -1 --no-merges --pretty=format:"%s" | npx commitlint --config commitlint.config.js --verbose

--- a/.github/workflows/contribution-lint.yaml
+++ b/.github/workflows/contribution-lint.yaml
@@ -36,6 +36,6 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Run Pull Request Title Validation
-        uses: JulienKode/pull-request-name-linter-action@v0.5.0
+        run: echo "${{ github.event.pull_request.title }}" | npx commitlint --config commitlint.config.js --verbose
       - name: Run Latest Commit Message Validation
         run: git log -1 --pretty=format:"%s" | npx commitlint --config commitlint.config.js --verbose


### PR DESCRIPTION
## Situation
Due to an ES Modules issue, almost all of the recent pull requests have been failing on pull request title lint validation. 

## Task
Fix the issue in the [GitHub action responsible for pull request title validation](https://github.com/ExpediaGroup/expediagroup-python-sdk/blob/ef068744f57357c112d7dd626d5dbc4959f7ce10/.github/workflows/contribution-lint.yaml#L38).

Also, since the reusable [GitHub action used for pull request title validation](https://github.com/JulienKode/pull-request-name-linter-action) seems to not being maintained, and the latest commit merged to the default branch was done 2 years ago at the time of creating this pull request, we need to find an alternative solution.

## Action
Since the rules for validating pull request titles and commit messages are identical, we can use `commitlint` to handle the pull request title validation, producing an identical approach to how we validate commit messages. 

Pull request titles can be accessed through the [`pull_request`](https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request) object's attribute `title`. The `pull_request` object is created per pull request based on the event of creating one.

Thus pull request titles can be validated through `commitlint`.

## Result
Pull request title validation now works as expected.

## Notes
+ For the `Run Latest Commit Message Validation` step, we added the `git log` option [`--no-merges`](https://git-scm.com/docs/git-log#Documentation/git-log.txt---no-merges), to avoid merge messages from being validated instead of the actual commit message. (e.g. `Merge SOME_BRANCH into OTHER_BRANCH` instead of `chore: sample commit message`).